### PR TITLE
URL Cleanup

### DIFF
--- a/doc/reference/lib/fop-0.95/lib/README.txt
+++ b/doc/reference/lib/fop-0.95/lib/README.txt
@@ -5,7 +5,7 @@ Information on Apache FOP dependencies
 $Id$
 
 The Apache Licenses can also be found here:
-http://www.apache.org/licenses/
+https://www.apache.org/licenses/
 
 
 Normal Dependencies

--- a/doc/reference/lib/fop-0.95/lib/avalon-framework.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/avalon-framework.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/doc/reference/lib/fop-0.95/lib/batik.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/batik.LICENSE.txt
@@ -1,6 +1,6 @@
                                   Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/commons-io.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-io.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/commons-logging.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-logging.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/serializer.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/serializer.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xalan.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xalan.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xercesImpl.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xercesImpl.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/src/introduction.xml
+++ b/doc/reference/src/introduction.xml
@@ -115,7 +115,7 @@
 
     <para>Spring.NET Social Framework is licensed according to the terms of the Apache License,
     Version 2.0. The full text of this license are available online at <ulink
-    url="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</ulink>
+    url="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</ulink>
     . You can also view the full text of the license in the license.txt file
     located in the root directory of the distribution.</para>
   </section>

--- a/examples/Common/Spring.Social.Do/Social/Do/Api/DoServiceProvider.cs
+++ b/examples/Common/Spring.Social.Do/Social/Do/Api/DoServiceProvider.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Do/Social/Do/Api/IDo.cs
+++ b/examples/Common/Spring.Social.Do/Social/Do/Api/IDo.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Do/Social/Do/Api/Impl/DoTemplate.cs
+++ b/examples/Common/Spring.Social.Do/Social/Do/Api/Impl/DoTemplate.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Facebook/Social/Facebook/Api/FacebookServiceProvider.cs
+++ b/examples/Common/Spring.Social.Facebook/Social/Facebook/Api/FacebookServiceProvider.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Facebook/Social/Facebook/Api/IFacebook.cs
+++ b/examples/Common/Spring.Social.Facebook/Social/Facebook/Api/IFacebook.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Facebook/Social/Facebook/Api/Impl/FacebookOAuth2Template.cs
+++ b/examples/Common/Spring.Social.Facebook/Social/Facebook/Api/Impl/FacebookOAuth2Template.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Facebook/Social/Facebook/Api/Impl/FacebookTemplate.cs
+++ b/examples/Common/Spring.Social.Facebook/Social/Facebook/Api/Impl/FacebookTemplate.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Github/Social/GitHub/Api/GitHubServiceProvider.cs
+++ b/examples/Common/Spring.Social.Github/Social/GitHub/Api/GitHubServiceProvider.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Github/Social/GitHub/Api/IGitHub.cs
+++ b/examples/Common/Spring.Social.Github/Social/GitHub/Api/IGitHub.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Github/Social/GitHub/Api/Impl/GitHubTemplate.cs
+++ b/examples/Common/Spring.Social.Github/Social/GitHub/Api/Impl/GitHubTemplate.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.LinkedIn/Social/LinkedIn/Api/ILinkedIn.cs
+++ b/examples/Common/Spring.Social.LinkedIn/Social/LinkedIn/Api/ILinkedIn.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.LinkedIn/Social/LinkedIn/Api/Impl/LinkedInTemplate.cs
+++ b/examples/Common/Spring.Social.LinkedIn/Social/LinkedIn/Api/Impl/LinkedInTemplate.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.LinkedIn/Social/LinkedIn/Api/LinkedInProfile.cs
+++ b/examples/Common/Spring.Social.LinkedIn/Social/LinkedIn/Api/LinkedInProfile.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.LinkedIn/Social/LinkedIn/Api/LinkedInServiceProvider.cs
+++ b/examples/Common/Spring.Social.LinkedIn/Social/LinkedIn/Api/LinkedInServiceProvider.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Twitter/Social/Twitter/Api/ITwitter.cs
+++ b/examples/Common/Spring.Social.Twitter/Social/Twitter/Api/ITwitter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Twitter/Social/Twitter/Api/Impl/TwitterTemplate.cs
+++ b/examples/Common/Spring.Social.Twitter/Social/Twitter/Api/Impl/TwitterTemplate.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Common/Spring.Social.Twitter/Social/Twitter/Api/TwitterServiceProvider.cs
+++ b/examples/Common/Spring.Social.Twitter/Social/Twitter/Api/TwitterServiceProvider.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/IApiBinding.cs
+++ b/src/Spring.Social.Core/Social/IApiBinding.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/IServiceProvider.cs
+++ b/src/Spring.Social.Core/Social/IServiceProvider.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth1/AbstractOAuth1ApiBinding.cs
+++ b/src/Spring.Social.Core/Social/OAuth1/AbstractOAuth1ApiBinding.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth1/AbstractOAuth1ServiceProvider.cs
+++ b/src/Spring.Social.Core/Social/OAuth1/AbstractOAuth1ServiceProvider.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth1/AuthorizedRequestToken.cs
+++ b/src/Spring.Social.Core/Social/OAuth1/AuthorizedRequestToken.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth1/IOAuth1Operations.cs
+++ b/src/Spring.Social.Core/Social/OAuth1/IOAuth1Operations.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth1/IOAuth1ServiceProvider.cs
+++ b/src/Spring.Social.Core/Social/OAuth1/IOAuth1ServiceProvider.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth1/OAuth1Parameters.cs
+++ b/src/Spring.Social.Core/Social/OAuth1/OAuth1Parameters.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth1/OAuth1RequestInterceptor.cs
+++ b/src/Spring.Social.Core/Social/OAuth1/OAuth1RequestInterceptor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth1/OAuth1Template.cs
+++ b/src/Spring.Social.Core/Social/OAuth1/OAuth1Template.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth1/OAuth1Version.cs
+++ b/src/Spring.Social.Core/Social/OAuth1/OAuth1Version.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth1/OAuthToken.cs
+++ b/src/Spring.Social.Core/Social/OAuth1/OAuthToken.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth1/SigningSupport.cs
+++ b/src/Spring.Social.Core/Social/OAuth1/SigningSupport.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth2/AbstractOAuth2ApiBinding.cs
+++ b/src/Spring.Social.Core/Social/OAuth2/AbstractOAuth2ApiBinding.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth2/AbstractOAuth2ServiceProvider.cs
+++ b/src/Spring.Social.Core/Social/OAuth2/AbstractOAuth2ServiceProvider.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth2/AccessGrant.cs
+++ b/src/Spring.Social.Core/Social/OAuth2/AccessGrant.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth2/GrantType .cs
+++ b/src/Spring.Social.Core/Social/OAuth2/GrantType .cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth2/IOAuth2Operations.cs
+++ b/src/Spring.Social.Core/Social/OAuth2/IOAuth2Operations.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth2/IOAuth2ServiceProvider.cs
+++ b/src/Spring.Social.Core/Social/OAuth2/IOAuth2ServiceProvider.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth2/OAuth2Parameters.cs
+++ b/src/Spring.Social.Core/Social/OAuth2/OAuth2Parameters.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth2/OAuth2RequestInterceptor.cs
+++ b/src/Spring.Social.Core/Social/OAuth2/OAuth2RequestInterceptor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth2/OAuth2Template.cs
+++ b/src/Spring.Social.Core/Social/OAuth2/OAuth2Template.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/OAuth2/OAuth2Version.cs
+++ b/src/Spring.Social.Core/Social/OAuth2/OAuth2Version.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Core/Social/SocialException.cs
+++ b/src/Spring.Social.Core/Social/SocialException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Social.Core.Tests/Social/OAuth1/AbstractOAuth1ApiBindingTests.cs
+++ b/test/Spring.Social.Core.Tests/Social/OAuth1/AbstractOAuth1ApiBindingTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Social.Core.Tests/Social/OAuth1/OAuth1TemplateTests.cs
+++ b/test/Spring.Social.Core.Tests/Social/OAuth1/OAuth1TemplateTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Social.Core.Tests/Social/OAuth1/SigningSupportTests.cs
+++ b/test/Spring.Social.Core.Tests/Social/OAuth1/SigningSupportTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Social.Core.Tests/Social/OAuth2/AbstractOAuth2ApiBindingTests.cs
+++ b/test/Spring.Social.Core.Tests/Social/OAuth2/AbstractOAuth2ApiBindingTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Social.Core.Tests/Social/OAuth2/OAuth2TemplateTests.cs
+++ b/test/Spring.Social.Core.Tests/Social/OAuth2/OAuth2TemplateTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 12 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 58 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).